### PR TITLE
refactor: don't rely on knowing whether `nuxt-vite` is installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "jest": "latest",
     "loader-utils": "latest",
     "nuxt-edge": "2.16.0-26922275.d55864da",
-    "nuxt-vite": "^0.0.29",
+    "nuxt-vite": "^0.0.32",
     "pug": "^3.0.2",
     "pug-plain-loader": "^1.1.0",
     "release-it": "^14.4.1",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./": "./",
-    "./src/vite/*": "./dist/vite/*",
-    "./src/webpack/*": "./dist/webpack/*"
+    "./src/template/*": "./dist/template/*"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,6 @@ const windicssModule: Module<UserOptions> = function (moduleOptions) {
     return
   }
 
-  const isViteMode = nuxtOptions.buildModules.includes('nuxt-vite')
-
   nuxt.hook('build:before', async () => {
     // allow users to override the windicss config
     // if they decided to return false - disabling windicss
@@ -51,27 +49,24 @@ const windicssModule: Module<UserOptions> = function (moduleOptions) {
     }
 
     logger.debug('Post hook options', options)
+    
+    // add plugin to import windi.css
+    nuxt.options.plugins.push(resolve(__dirname, 'template', 'windicss.js'))
 
-    if (!isViteMode) {
-      this.extendBuild((config: WebpackConfig,) => {
-        if (! config.plugins) { config.plugins = [] }
-        config.plugins.push(
-            // push our webpack plugin
-            new WindiCSSWebpackPlugin(options)
+    this.extendBuild((config: WebpackConfig,) => {
+      if (! config.plugins) { config.plugins = [] }
+      config.plugins.push(
+        // push our webpack plugin
+        new WindiCSSWebpackPlugin(options)
         )
       })
-      // add plugin to import windi.css
-      nuxt.options.plugins.push(resolve(__dirname, 'webpack', 'plugins', 'windicss.js'))
-    } else {
-      nuxt.options.plugins.push(resolve(__dirname, 'vite', 'plugins', 'windicss.js'))
-    }
-  })
-
-  if (isViteMode) {
-    nuxt.hook('vite:extend', ({config, nuxt}: { nuxt: { options: NuxtOptions }, config: { plugins: any[] } }) => {
-      config.plugins.push(WindiCSSVitePlugin(options))
     })
-  }
+    
+  
+  nuxt.hook('vite:extend', ({config, nuxt}: { nuxt: { options: NuxtOptions }, config: { plugins: any[] } }) => {
+    nuxt.options.alias['windi.css'] = '@virtual/windi.css'
+    config.plugins.push(WindiCSSVitePlugin(options))
+  })
 
 }
 

--- a/src/template/windicss.js
+++ b/src/template/windicss.js
@@ -1,0 +1,1 @@
+import 'windi.css'

--- a/src/vite/plugins/windicss.js
+++ b/src/vite/plugins/windicss.js
@@ -1,1 +1,0 @@
-import '@virtual/windi.css'

--- a/src/webpack/plugins/windicss.js
+++ b/src/webpack/plugins/windicss.js
@@ -1,1 +1,0 @@
-require('windi.css')

--- a/yarn.lock
+++ b/yarn.lock
@@ -11177,10 +11177,10 @@ nuxt-edge@2.16.0-26922275.d55864da:
     "@nuxt/vue-renderer-edge" "2.16.0-26922275.d55864da"
     "@nuxt/webpack-edge" "2.16.0-26922275.d55864da"
 
-nuxt-vite@^0.0.29:
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/nuxt-vite/-/nuxt-vite-0.0.29.tgz#1e02a5c4a11bbe1992a06954b47315b52bef5952"
-  integrity sha512-UZeSWX5jiixh37hO++Wfgln0XIDiLNsrGQ1w9Le8wvq11R4VxIPBpX0Qz89e1jyblVpKgVNO36Sz5ESnbfJO0g==
+nuxt-vite@^0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/nuxt-vite/-/nuxt-vite-0.0.32.tgz#b3c502966ec5d3ef43fa0027e592105769709212"
+  integrity sha512-mNAuQulgot8FgMqGYf8k1916Di0fnlLQGsnlic1sZ44wleg2wSOgviuV2QWoAScQtupQfSFR6ac1FybiRNXcJQ==
   dependencies:
     "@nuxt/http" "^0.6.4"
     chokidar "^3.5.1"


### PR DESCRIPTION
We need to support *both* vite & webpack and so can't rely on `isViteMode`. Note also that at the moment [this change](https://github.com/nuxt/vite/commit/ad46140f7139ffba84e148034d485b3837c2a552) in **nuxt/vite** will break this module.

I realise you previously said you had issues with `import 'windi.css'` but I can't replicate that in local testing