### PR TITLE
feat!: read from user config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ buildModules: [
 ],
 ```
 
-This module will read from your root `tailwind.config.js` or `windi.config.js` config if present. See [here](https://windicss.netlify.app/guide/configuration.html) for details.
+If you have a `tailwind.config.js`, please rename it to `windi.config.js`.
+
+This module will read from `windi.config.js` config if present. See [here](https://windicss.netlify.app/guide/configuration.html) for details.
 
 
 ## Migrating

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test": "yarn lint && jest --verbose --detectOpenHandles"
   },
   "dependencies": {
+    "clear-module": "^4.1.1",
     "defu": "^3.2.2",
     "rimraf": "^3.0.2",
     "semver": "^7.3.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,12 +50,14 @@ const windicssModule: Module<UserOptions> = function (moduleOptions) {
     const configPath = nuxt.resolver.resolveAlias(config.config)
     if (existsSync(configPath)) {
       clearModule(configPath)
-      logger.info(`Reading Windi config from ~/windi.config.js`)
+      logger.info(`Reading Windi config from ${config.config}`)
       config.config = nuxt.resolver.requireModule(configPath)
       // Restart Nuxt if windi file updates (for modules using windicss:config hook)
       if (nuxt.options.dev) {
         nuxt.options.watch.push(configPath)
       }
+    } else {
+      config.config = {}
     }
   } else {
     logger.info('Reading Windi config from Nuxt config `windicss.config` property')


### PR DESCRIPTION
This PR reads the user file directly, allowing smarter merging using the `windicss:config` hook.

Breaking changes:
- Removed reading from `tailwindcss` property since we recommend to remove the Tailwind module.
- Removed reading from `tailwind.config.js`

---

I don't know if this is related, but it works with vite and got this issue with Webpack, looks like the `exclude` does not work properly.

![Screenshot 2021-03-19 at 19 09 01](https://user-images.githubusercontent.com/904724/111824493-947ce200-88e6-11eb-988c-ebea81ef92c4.png)
