### PR TITLE
fix(config): exclude node_modules_prod (#86)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ const windicssModule: Module<UserOptions> = function(moduleOptions) {
       exclude: [
         'node_modules',
         'node_modules_dev',
+        'node_modules_prod',
         'dist',
         '.git',
         '.github',


### PR DESCRIPTION
The nuxt/vercel-builder package will generate node_modules_dev and further node_modules_prod folders.