### PR TITLE
feat(hook): expose utils instance via hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ const windicssModule: Module<UserOptions> = async function(moduleOptions) {
     preflight: false,
     scan: false,
   }, { root: windiConfig.root })
+  nuxt.callHook('windicss:utils', utils)
   await utils.init()
 
   nuxt.hook('build:before', () => {


### PR DESCRIPTION
This could be useful for other modules to reuse the utils instance with the injected configure (e.g. fire up a windicss analyser without scan again) 