### PR TITLE
fix: improve perf by reuse utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
     "upath": "^2.0.1",
-    "vite-plugin-windicss": "1.1.1",
+    "vite-plugin-windicss": "1.2.0",
     "windicss-webpack-plugin": "1.2.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3665,10 +3665,10 @@
     micromatch "^4.0.4"
     windicss "^3.1.3"
 
-"@windicss/plugin-utils@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@windicss/plugin-utils/-/plugin-utils-1.1.1.tgz#7f70952adc8d33f607706e434a153e2cdff52b64"
-  integrity sha512-niKEDyUpOfCGemFHopI9fxdWPpJQIZ/jmaU4spQXsGc1oEts164P8LUJPQmXc8C6vjKwkrH7KA+lxYNG5LmlDA==
+"@windicss/plugin-utils@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@windicss/plugin-utils/-/plugin-utils-1.2.0.tgz#f9c657f981d7696dfa6b8e8069b311161a2ac9b4"
+  integrity sha512-6OAsyz2yI0VKNHACT35FjWWzMZlMEF7Z0pIiNUd9+R9jc73+qJcK1DRCZ3YxnjuGk0G76b542uXQEJgv2jL3vA==
   dependencies:
     "@antfu/utils" "^0.2.3"
     debug "^4.3.2"
@@ -17190,12 +17190,12 @@ vite-plugin-vue2@^1.4.4:
     vue-template-compiler "^2.6.11"
     vue-template-es2015-compiler "^1.9.1"
 
-vite-plugin-windicss@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/vite-plugin-windicss/-/vite-plugin-windicss-1.1.1.tgz#c13d4c2d9fec4afae2eea5058f426c693255d02f"
-  integrity sha512-J1n3DoSg8BkQ42HDNzh+FqPhvBgCRgQ0Nvp2HLvb5FVl8FKEPw26Frc/oLaC1g9ypSlvkSM8011gHi+c+pxsRQ==
+vite-plugin-windicss@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-windicss/-/vite-plugin-windicss-1.2.0.tgz#6b21e76f3aae1cd2f71c548c4bfe8d87b4328ad0"
+  integrity sha512-3teAmQHCDDDcy7On5fOj1sYTRVo8zAwJJd4SOapeGI7EuEzO2fHy6oDS6sPXVUnstbfoPbvrng1xvc3VAqI+sg==
   dependencies:
-    "@windicss/plugin-utils" "1.1.1"
+    "@windicss/plugin-utils" "1.2.0"
     chalk "^4.1.1"
     debug "^4.3.2"
     windicss "^3.1.3"


### PR DESCRIPTION
I have noticed this module uses vite plugin and webpack plugin underneath, while each of them have their own utils, could cause scanning for multiple times.

- Vite plugin v1.2 now expose option to pass utils instance, https://github.com/windicss/vite-plugin-windicss/commit/951e97b8a96190a40432e07f10812be64f831bcc
- Wepback plugin: https://github.com/windicss/windicss-webpack-plugin/pull/83 (need to merge it before this and then bump the dep)
- Make `utils.init` resolves in parallel and make the module sync (use `utils.ensureInit()` in hooks)